### PR TITLE
feat(api): implement user retrieve sent messages

### DIFF
--- a/src/controllers/message.js
+++ b/src/controllers/message.js
@@ -19,6 +19,15 @@ const Message = {
 
     return res.status(200).json({ status: 200, data: newMessage });
   },
+  getAllSentMessages(req, res) {
+    const newMessage = MessageModel.getAllSentMessages(req.body);
+    if (newMessage.error) {
+      return res.status(400).json({ status: 400, error: newMessage.error });
+    }
+
+
+    return res.status(200).json({ status: 200, data: newMessage });
+  },
 
 
 };

--- a/src/routes/route.js
+++ b/src/routes/route.js
@@ -8,5 +8,6 @@ router.post('/auth/signup', User.create);
 router.post('/auth/login', User.login);
 router.post('/messages', Message.post);
 router.get('/messages', Message.getInbox);
+router.get('/messages/sent', Message.getAllSentMessages);
 
 export default router;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -91,7 +91,6 @@ describe('POST /api/v1/messages', () => {
         .post('/api/v1/messages')
         .send(data)
         .end((err, res) => {
-          console.log(res.body);
           expect(res.body).to.have.property('status');
           expect(res.body).to.have.property('data').to.be.a('array');
           done();
@@ -129,7 +128,7 @@ describe('GET /api/v1/messages', () => {
       chai.request(server)
         .get('/api/v1/messages')
         .send(data)
-        .end((err, res) => {          
+        .end((err, res) => {
           expect(res.body).to.have.property('status').equal(200);
           expect(res.body).to.have.property('data').to.be.a('array');
           done();
@@ -143,6 +142,40 @@ describe('GET /api/v1/messages', () => {
       };
       chai.request(server)
         .get('/api/v1/messages')
+        .send(data)
+        .end((err, res) => {
+          expect(res.body).to.have.property('status');
+          expect(res.body).to.have.property('error').to.be.a('string');
+          done();
+        });
+    });
+  });
+});
+
+describe('GET /api/v1/messages/sent', () => {
+  describe('When a user tries to retrieve a sent message with a valid account', () => {
+    it('should return an object with the status and data', (done) => {
+      const data = {
+        email: 'aobikobe@gmail.com',
+      };
+
+      chai.request(server)
+        .get('/api/v1/messages/sent')
+        .send(data)
+        .end((err, res) => {
+          expect(res.body).to.have.property('status').equal(200);
+          expect(res.body).to.have.property('data').to.be.a('array');
+          done();
+        });
+    });
+  });
+  describe('When a user tries to retrieve a sent message with an invalid account', () => {
+    it('should return an object with the status and error', (done) => {
+      const data = {
+        email: '123@gmail.com',
+      };
+      chai.request(server)
+        .get('/api/v1/messages/sent')
         .send(data)
         .end((err, res) => {
           expect(res.body).to.have.property('status');


### PR DESCRIPTION
#### What does this PR do?
- [Delivers Story:164358557-implement user retrieve sent messages ]

#### Description of Task to be completed?
- Write spec tests for the router class
- Define endpoint and method for retrieval of all sent messages by a usere

#### How should this be manually tested?
- Run
```
npm run test
npm run build
npm run serve
```
- Run the url (http://localhost:3000/api/v1/messages/sent) on Postman with GET selected.

#### What are the relevant pivotal tracker stories?
- PT Story link - (`[164358557](https://www.pivotaltracker.com/story/show/164358557)`)