### PR TITLE
feat(api): implement user retrieve unread messages

### DIFF
--- a/src/controllers/message.js
+++ b/src/controllers/message.js
@@ -28,6 +28,15 @@ const Message = {
 
     return res.status(200).json({ status: 200, data: newMessage });
   },
+  getAllUnreadMessages(req, res) {
+    const newMessage = MessageModel.getUnreadInbox(req.body);
+    if (newMessage.error) {
+      return res.status(400).json({ status: 400, error: newMessage.error });
+    }
+
+
+    return res.status(200).json({ status: 200, data: newMessage });
+  },
 
 
 };

--- a/src/models/message.js
+++ b/src/models/message.js
@@ -103,7 +103,7 @@ class Message {
     }
     // const message = this.messages.find(m => m.senderId === sender.id);
     const message = this.messages.reduce((arr, msg) => {
-      if (msg.senderId === sender.id) {
+      if (msg.senderId === sender.id && msg.status !== 'drafft') {
         arr.push(msg);
       }
       return arr;
@@ -126,7 +126,7 @@ class Message {
     }
     // const message = this.messages.find(m => m.senderId === sender.id);
     const message = this.messages.reduce((arr, msg) => {
-      if (msg.receiverId === receiver.id) {
+      if (msg.receiverId === receiver.id && msg.status !== 'draft') {
         arr.push(msg);
       }
       return arr;
@@ -149,7 +149,7 @@ class Message {
     }
     // const message = this.messages.find(m => m.senderId === sender.id);
     const message = this.messages.reduce((arr, msg) => {
-      if (msg.receiverId === receiver.id && msg.status !== 'read') {
+      if (msg.receiverId === receiver.id && msg.status !== 'read' && msg.status !== 'draft') {
         arr.push(msg);
       }
       return arr;

--- a/src/routes/route.js
+++ b/src/routes/route.js
@@ -9,5 +9,6 @@ router.post('/auth/login', User.login);
 router.post('/messages', Message.post);
 router.get('/messages', Message.getInbox);
 router.get('/messages/sent', Message.getAllSentMessages);
+router.get('/messages/unread', Message.getAllUnreadMessages);
 
 export default router;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -185,3 +185,37 @@ describe('GET /api/v1/messages/sent', () => {
     });
   });
 });
+
+describe('GET /api/v1/messages/unread', () => {
+  describe('When a user tries to retrieve an unread message with a valid account', () => {
+    it('should return an object with the status and data', (done) => {
+      const data = {
+        email: 'aobikobe@gmail.com',
+      };
+
+      chai.request(server)
+        .get('/api/v1/messages/unread')
+        .send(data)
+        .end((err, res) => {
+          expect(res.body).to.have.property('status').equal(200);
+          expect(res.body).to.have.property('data').to.be.a('array');
+          done();
+        });
+    });
+  });
+  describe('When a user tries to retrieve an unread message with an invalid account', () => {
+    it('should return an object with the status and error', (done) => {
+      const data = {
+        email: '123@gmail.com',
+      };
+      chai.request(server)
+        .get('/api/v1/messages/unread')
+        .send(data)
+        .end((err, res) => {
+          expect(res.body).to.have.property('status');
+          expect(res.body).to.have.property('error').to.be.a('string');
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
- [Delivers Story:164358547-implement user retrieve unread messages ]

#### Description of Task to be completed?
- Write spec tests for the router class
- Define endpoint and method for retrieval of received messages (Inbox)
- Modified some of the methods in the src/models/message.js file to reflect sent message is denoted by message status is not draft and unread message is when message status is not read nor draft


#### How should this be manually tested?
- Run
```
npm run test
npm run build
npm run serve
```
- Run the url (http://localhost:3000/api/v1/messages/unread) on Postman with GET selected.

#### What are the relevant pivotal tracker stories?
- PT Story link - (`[164358547](https://www.pivotaltracker.com/story/show/164358547)`)