### PR TITLE
Bug(api): set babel node as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "dependencies": {
     "@babel/core": "^7.3.4",
     "express": "^4.16.4",
+    "@babel/node": "^7.2.2",
     "nodemon": "^1.18.10"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.0.0",
-    "@babel/node": "^7.2.2",
     "@babel/preset-env": "^7.3.4",
     "@babel/register": "^7.0.0",
     "chai": "^4.2.0",


### PR DESCRIPTION
#### What does this PR do?
- [Delivers Story:164510495 ]

#### Description of Task to be completed?
- add babel node  to dependencies instead of devdependencies

#### How should this be manually tested?
- Run
```
npm run start
```
- Run the url (http://localhost:3000/api/v1/messages) on Postman with GET selected.

#### What are the relevant pivotal tracker stories?
- PT Story link - ([164510495](https://www.pivotaltracker.com/story/show/164510495))